### PR TITLE
Manifest typo

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "background": { "page": "index.html?background", "persistant": false },
+  "background": { "page": "index.html?background", "persistent": false },
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "description": "See most recent SAML response",
   "icons": {


### PR DESCRIPTION
Noticed this when sideloading this as a Firefox addon since it emits a warning. Assume Chrome is just defaulting it to false.